### PR TITLE
Set "text/javascript" type if given a callback

### DIFF
--- a/freegeoip/geoip.py
+++ b/freegeoip/geoip.py
@@ -67,8 +67,9 @@ class XmlHandler(BaseHandler):
 class JsonHandler(BaseHandler):
     def dump(self, data):
         callback = self.get_argument("callback", None)
-        self.set_header("Content-Type", "application/json")
         if callback:
+            self.set_header("Content-Type", "text/javascript")
             self.finish("%s(%s);" % (callback, cyclone.escape.json_encode(data)))
         else:
+            self.set_header("Content-Type", "application/json")
             self.finish(cyclone.escape.json_encode(data))


### PR DESCRIPTION
If callback is passed to the JSON service, we can assume it is called from a browser, so the correct MIME type for the response would be "text/javascript" instead of "application/json" (even more since it's not pure JSON but a function call code).

This will fix Chrome warnings in the console "Resource interpreted as Script but transferred with MIME type application/json.".
