### PR TITLE
clean-o

### DIFF
--- a/database/createdb.py
+++ b/database/createdb.py
@@ -16,7 +16,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import simplejson
+import json
 import os, sys, csv, sqlite3
 
 dbname = "ipdb.sqlite"
@@ -36,7 +36,7 @@ class import_city:
             for k, v in zip(headers[1:], row[1:]):
                 data[k] = str(v)
 
-            entities.append([row[0], simplejson.dumps(data)])
+            entities.append([row[0], json.dumps(data)])
 
             count += 1
             if count % 10000 == 0:

--- a/freegeoip.conf
+++ b/freegeoip.conf
@@ -5,8 +5,8 @@ xsrf_cookies = false
 cookie_secret = QCnLhoN2S8KujKPTJhKatmpqhKFiJUWZrWWRqZjgJWg=
 
 [limits]
-expire = 3600
-max_requests = 1000
+expire = 300
+max_requests = 10
 
 [frontend]
 static_path = frontend/static


### PR DESCRIPTION
- changed quota to throttle control for API: less overhead each request, configurable per minute/hour/day (just change the key), can expires by whatever time it's needed (say each minute 10 req max, or 10 reqs each 10 secs, etc)
- createdb.py now uses json instead of simplejson

< 18 minutes including the db download/generation. power to the beard.
