### PR TITLE
Missing dependencies in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,6 @@ Install the package:
 
 Install the web server:
 
-	go get github.com/fiorix/go-redis/redis
-	go get github.com/gorilla/context
-	go install github.com/fiorix/freegeoip/cmd/freegeoip
+	go get github.com/fiorix/freegeoip/cmd/freegeoip
 
 Test coverage is quite good and may help you find the stuff you need.


### PR DESCRIPTION
When following the setup instructions for installing the web server, I ran into errors related to missing dependencies. Here's an example of the errors on a completely fresh install (go version 1.3.3):

``` sh
$ export GOPATH=/tmp/freegeoip
$ go get github.com/fiorix/freegeoip
$ go install github.com/fiorix/freegeoip/cmd/freegeoip
/tmp/freegeoip/src/github.com/fiorix/freegeoip/cmd/freegeoip/main.go:20:2: cannot find package "github.com/fiorix/go-redis/redis" in any of:
    /opt/local/go/src/pkg/github.com/fiorix/go-redis/redis (from $GOROOT)
    /tmp/freegeoip/src/github.com/fiorix/go-redis/redis (from $GOPATH)
/tmp/freegeoip/src/github.com/fiorix/freegeoip/cmd/freegeoip/main.go:21:2: cannot find package "github.com/gorilla/context" in any of:
    /opt/local/go/src/pkg/github.com/gorilla/context (from $GOROOT)
    /tmp/freegeoip/src/github.com/gorilla/context (from $GOPATH)
```

I was able to fix this by explicitly getting the `go-redis` and `context` packages before running the install command. This pull request simply updates the readme with these additional commands to get those packages.

However, I'm new to Go, so if there's a way to setup those packages as dependencies so they automatically get fetched, that might be preferable, but I at least wanted to raise the issue for anyone else that might be running into this on a fresh install.

Thanks for the great package!
