### PR TITLE
Expose 8080 by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN cd /go/src/github.com/fiorix/freegeoip/cmd/freegeoip && go get && go install
 
 ENTRYPOINT ["/go/bin/freegeoip"]
 
+EXPOSE 8080
+
 # CMD instructions:
 # Add  "-use-x-forwarded-for"      if your server is behind a reverse proxy
 # Add  "-public", "/var/www"       to enable the web front-end


### PR DESCRIPTION
Expose port 8080 to allow seamless linking with other containers (like nginx, haproxy, etc.)