### PR TITLE
Fix the run docs to expose in cross-platform manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yum install docker
 Run the freegeoip web server:
 
 ```bash
-docker run --net=host --restart=always -d fiorix/freegeoip
+docker run --restart=always -p 8080:8080 -d fiorix/freegeoip
 ```
 
 Test:


### PR DESCRIPTION
More discussion on how this works on Mac can be found at the following:

- https://github.com/docker/for-mac/issues/68#issuecomment-238687969
- https://forums.docker.com/t/should-docker-run-net-host-work/14215